### PR TITLE
Calculate remaining buffer length based on current rule length

### DIFF
--- a/rbBoundingBoxes/geo_rule_builder.rb
+++ b/rbBoundingBoxes/geo_rule_builder.rb
@@ -287,7 +287,7 @@ class GeoRuleBuilder
                     rule = "#{rule_base} (#{clause}"
                     empty_rule = false
                 end
-                current_buffer = current_buffer - clause.length
+                current_buffer = starting_buffer - rule.length
 
                 if i == num_of_clauses then
                     rule = "#{rule}) ".strip!


### PR DESCRIPTION
We found that rules were being generated that were longer than the
1024 character limit.  With this fix, the buffer size is calculated
based on the starting buffer size minus the current rule size to
take into account things like "OR" or spaces added into the rule.
